### PR TITLE
map image :bug: fix by specifying minZoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -1209,6 +1209,7 @@
       }
       else {
          L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw', {
+            minZoom: 1,
             maxZoom: 18,
             attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             id: 'mapbox/streets-v11',


### PR DESCRIPTION
This fixes a 404 error when fully zooming out from the map by defining [minZoom](https://leafletjs.com/reference.html#tilelayer-minzoom). This prevents the user from zooming out too far, causing the map image not to load.

Example:
```
GET https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/-1/0/0 404 (Not Found)
```

<img width="278" alt="image" src="https://user-images.githubusercontent.com/1467153/200686238-ed6d6225-4649-469d-ac3e-fdb4c0596907.png">
